### PR TITLE
Configure kibana advanced settings

### DIFF
--- a/kibana/dashboards/index-pattern/logstash.json
+++ b/kibana/dashboards/index-pattern/logstash.json
@@ -1,1 +1,4 @@
-{"title":"logstash-*","timeFieldName":"@timestamp"}
+{
+  "timeFieldName": "@timestamp",
+  "title": "logstash-*"
+}

--- a/kibana/entrypoint.sh
+++ b/kibana/entrypoint.sh
@@ -13,5 +13,7 @@ echo "Loading dashboards"
 cd /tmp
 ./load.sh
 
+[ ! -f /tmp/.initialized ] && echo "Configuring default settings" && curl -XPUT http://elk-elasticsearch:9200/.kibana/config/4.4.1 -d '{"dashboard:defaultDarkTheme": true, "defaultIndex": "logstash-*"}' && touch /tmp/.initialized
+
 echo "Starting Kibana"
 exec kibana


### PR DESCRIPTION
This will configure the first time the container starts :
* dashboard:defaultDarkTheme to true
* defaultIndex to logstash-*

This also fixes the format of logstash.conf index-pattern file (because the load script parsing is very limited)