### PR TITLE
Fix syntax in bootstrap/docker-compose file

### DIFF
--- a/bootstrap/docker-compose.yml
+++ b/bootstrap/docker-compose.yml
@@ -32,6 +32,6 @@ services:
         #    - ./dashboards:/tmp/dashboards
     jhipster-alerter:
         image: jhipster/jhipster-alerter
-        volumes:
+        #volumes:
         #    - ./jhipster-alerter/rules/:/opt/elastalert/rules/
         #    - ./alerts/config.yaml:/opt/elastalert/config.yaml


### PR DESCRIPTION
Fix this syntax error:
```
ERROR: The Compose file './docker-compose.yml' is invalid because:
services.jhipster-alerter.volumes contains an invalid type, it should be an array
```