### PR TITLE
Upgrade jhipster-console

### DIFF
--- a/jhipster-alerter/Dockerfile
+++ b/jhipster-alerter/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:2.7-alpine
 
-RUN apk update && apk upgrade && apk add bash curl tar musl-dev linux-headers g++
+RUN apk update && apk upgrade && apk add bash curl tar musl-dev linux-headers g++ libffi-dev libffi openssl-dev
 
 ENV SET_CONTAINER_TIMEZONE false
-ENV ELASTALERT_VERSION v0.1.8
+ENV ELASTALERT_VERSION v0.1.14
 ENV CONTAINER_TIMEZONE Europe/Paris
 ENV ELASTALERT_URL https://github.com/Yelp/elastalert/archive/${ELASTALERT_VERSION}.tar.gz
 
@@ -23,8 +23,8 @@ RUN curl -Lo elastalert.tar.gz ${ELASTALERT_URL} && \
 
 WORKDIR /opt/elastalert
 
-RUN python setup.py install && \
-    pip install -e .
+RUN  pip install "setuptools>=11.3" \
+    python setup.py install
 
 COPY ./start-elastalert.sh /opt/start-elastalert.sh
 RUN chmod +x /opt/start-elastalert.sh

--- a/jhipster-console/Dockerfile
+++ b/jhipster-console/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.elastic.co/kibana/kibana:5.3.0
+FROM docker.elastic.co/kibana/kibana:5.4.0
 
 COPY kibana.yml /usr/share/kibana/config/kibana.yml

--- a/jhipster-elasticsearch/Dockerfile
+++ b/jhipster-elasticsearch/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:5.3.0
+FROM docker.elastic.co/elasticsearch/elasticsearch:5.4.0
 
 COPY config/ /usr/share/elasticsearch/config/

--- a/jhipster-logstash/Dockerfile
+++ b/jhipster-logstash/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/logstash/logstash:5.3.0
+FROM docker.elastic.co/logstash/logstash:5.4.0
 
 COPY logstash.yml /usr/share/logstash/config/
 COPY logstash.conf /usr/share/logstash/pipeline/

--- a/jhipster-zipkin/Dockerfile
+++ b/jhipster-zipkin/Dockerfile
@@ -1,8 +1,8 @@
-FROM openzipkin/zipkin:1.20
+FROM openzipkin/zipkin:1.26.0
 
 # Embed zipkin dependencies, a spark job to compute the graph between microservices
 ENV ZIPKIN_REPO https://jcenter.bintray.com
-ENV ZIPKIN_DEPENDENCIES_VERSION 1.4.0
+ENV ZIPKIN_DEPENDENCIES_VERSION 1.5.4
 ENV STORAGE_TYPE elasticsearch
 
 RUN apk add --no-cache coreutils && \


### PR DESCRIPTION
Upgrade elastalert version from v0.1.8 to v0.1.14
Upgrade Elastic Stack version from 5.3.0 to 5.4.0
Upgrade zipkin version from 1.20 to 1.26.0