### PR TITLE
added Elasticsearch Curator

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,14 @@ services:
     #         #- ./alerts/config.yaml:/opt/elastalert/config.yaml
     #         - ./alerts/rules/:/opt/elastalert/rules
 
+    # https://www.elastic.co/guide/en/elasticsearch/client/curator/current/configuration.html
+    #jhipster-curator:
+    #      build: jhipster-curator/
+    #      environment:
+    #          ES_HOST=jhipster-elasticsearch
+    #          UNIT_COUNT=7
+    #          UNIT=days
+
     jhipster-zipkin:
         build: jhipster-zipkin/
         environment:

--- a/jhipster-curator/Dockerfile
+++ b/jhipster-curator/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.6-alpine
+
+RUN pip install elasticsearch-curator
+
+COPY ./config/ /config
+
+RUN /usr/bin/crontab /config/crontab.txt
+
+CMD ["/usr/sbin/crond","-f"]

--- a/jhipster-curator/config/action_file.yml
+++ b/jhipster-curator/config/action_file.yml
@@ -1,0 +1,24 @@
+actions:
+  1:
+    action: delete_indices
+    description: >-
+       Delete indices older than ${UNIT_COUNT:1} ${UNIT:months} (based on index name), for logstash-
+       prefixed indices. Ignore the error if the filter does not result in an
+       actionable list of indices (ignore_empty_list) and exit cleanly.
+    options:
+      ignore_empty_list: True
+      timeout_override:
+      continue_if_exception: True
+      disable_action: False
+    filters:
+    - filtertype: pattern
+      kind: prefix
+      value: logstash-
+      exclude:
+    - filtertype: age
+      source: name
+      direction: older
+      timestring: '%Y.%m.%d'
+      unit: ${UNIT:months}
+      unit_count: ${UNIT_COUNT:1}
+      exclude:

--- a/jhipster-curator/config/config_file.yml
+++ b/jhipster-curator/config/config_file.yml
@@ -1,0 +1,21 @@
+---
+# Remember, leave a key empty if there is no value.  None will be a string,
+# not a Python "NoneType"
+client:
+  hosts:
+    - ${ES_HOST:127.0.0.1}
+  port: 9200
+  url_prefix:
+  use_ssl: ${USE_SSL:False}
+  certificate:
+  client_cert:
+  client_key:
+  ssl_no_validate: False
+  http_auth: ${HTTP_AUTH:''}
+  timeout: ${TIMEOUT:120}
+  master_only: ${MASTER_ONLY:True}
+logging:
+  loglevel: INFO
+  logfile:
+  logformat: default
+  #blacklist: ['elasticsearch', 'urllib3']

--- a/jhipster-curator/config/crontab.txt
+++ b/jhipster-curator/config/crontab.txt
@@ -1,0 +1,1 @@
+0 0 * * * curator --config /config/config_file.yml /config/action_file.yml


### PR DESCRIPTION
[Elasticsearch Curator](https://www.elastic.co/guide/en/elasticsearch/client/curator/current/about.html) helps you curate, or manage, your Elasticsearch indices and snapshots by:

Obtaining the full list of indices (or snapshots) from the cluster, as the actionable list
Iterate through a list of user-defined filters to progressively remove indices (or snapshots) from this actionable list as needed.
Perform various actions on the items which remain in the actionable list.