### PR TITLE
Fix field splitting

### DIFF
--- a/jhipster-logstash/logstash.conf
+++ b/jhipster-logstash/logstash.conf
@@ -19,7 +19,7 @@ filter {
     if [logger_name] =~ "metrics" {
         kv {
             source => "message"
-            field_split => ", "
+            field_split_pattern => ", "
             prefix => "metric_"
         }
 	mutate {


### PR DESCRIPTION
The metrics message is separated by two characters (space and comma), this requires the use of the field_split_pattern, otherwise unexpected space is left in the field name.