### PR TITLE
update the elastalert to v0.1.33 to support ES 6

### DIFF
--- a/jhipster-alerter/Dockerfile
+++ b/jhipster-alerter/Dockerfile
@@ -4,7 +4,7 @@ RUN apk update && apk upgrade && apk add bash curl tar musl-dev linux-headers g+
 
 ENV SET_CONTAINER_TIMEZONE=false \
     CONTAINER_TIMEZONE=UTC \
-    ELASTALERT_URL=https://github.com/Yelp/elastalert/archive/v0.1.25.tar.gz \
+    ELASTALERT_URL=https://github.com/Yelp/elastalert/archive/v0.1.33.tar.gz \
     ELASTALERT_HOME=/opt/elastalert \
     RULES_DIRECTORY=/opt/elastalert/rules \
     ES_HOST=jhipster-elasticsearch \


### PR DESCRIPTION
update the elastalert to `v0.1.33` to support the ES6

1. Current we use using version `v0.1.25`, it is released at  Dec 9, 2017. 
1. the ES6 support for elastalert come at 2018-01-07 , [Compatibility with Elastic 6](https://github.com/Yelp/elastalert/pull/1472)

the current `jhipster-alerter` can't work the `jhipster-elasticsearch 3.x`.  due to the breaking change for ES6. 