### PR TITLE
curator: Fix the issue with empty HTTP_AUTH

### DIFF
--- a/jhipster-curator/config/config_file.yml
+++ b/jhipster-curator/config/config_file.yml
@@ -11,7 +11,7 @@ client:
   client_cert:
   client_key:
   ssl_no_validate: False
-  http_auth: ${HTTP_AUTH:''}
+  http_auth: ${HTTP_AUTH}
   timeout: ${TIMEOUT:120}
   master_only: ${MASTER_ONLY:True}
 logging:


### PR DESCRIPTION
When HTTP_AUTH variable is empty curator is trying to use two single quotes as password ('') and fails connection to Elasticsearch. Fix it by removing default value.

Links:
- https://www.elastic.co/guide/en/elasticsearch/client/curator/current/envvars.html#_examples