### PR TITLE
Kibana: Fix ownership for kibana.yml

### DIFF
--- a/jhipster-console/Dockerfile
+++ b/jhipster-console/Dockerfile
@@ -2,6 +2,6 @@ FROM docker.elastic.co/kibana/kibana-oss:6.4.1
 
 ENV ELASTICSEARCH_URL=http://jhipster-elasticsearch:9200
 
-COPY kibana.yml /usr/share/kibana/config/kibana.yml
+COPY --chown=1000:0 kibana.yml /usr/share/kibana/config/kibana.yml
 RUN ./bin/kibana-plugin install https://github.com/sivasamyk/logtrail/releases/download/v0.1.30/logtrail-6.4.1-0.1.30.zip
 COPY logtrail.json /usr/share/kibana/plugins/logtrail/logtrail.json


### PR DESCRIPTION
- kibana.yml should be writable to allow installation of plugins

See https://github.com/elastic/kibana-docker/blob/6.4.1/templates/Dockerfile.j2#L48